### PR TITLE
Update bio with current work experience and skills

### DIFF
--- a/index.html
+++ b/index.html
@@ -128,32 +128,43 @@
       </div>
       <p>
         My name is <strong>Kavin</strong> and I am a
-        <strong>fullstack web developer</strong>
+        <strong>fullstack developer</strong>
         experienced in
-        <strong>Javascript, Typescript, Python and PHP</strong> and have also
+        <strong>TypeScript, JavaScript, Python and Rust</strong> and have
         worked with frameworks like
-        <strong>ReactJS, Express, Django and Laravel</strong>. I also have
-        experience doing <strong>App Development with Flutter</strong>.
+        <strong>React, Next.js, Django, Express and Laravel</strong>. I also have
+        experience building <strong>developer tools, SDKs, and mobile apps with Flutter</strong>.
+      </p>
+      <p>
+        I am currently a SWE Intern at
+        <a href="https://vercel.com" target="_blank" style="color: #000"
+          >Vercel</a
+        >. Previously, I shipped developer tooling at
+        <a href="https://www.helicone.ai" target="_blank" style="color: #0ea5e9"
+          >Helicone</a
+        >
+        (YC W23), building LLM observability features and an open-source
+        <a href="https://github.com/Helicone/ai-gateway" target="_blank">AI Gateway</a> in Rust.
       </p>
       <p>
         I am a former President of
         <a href="https://exunclan.com" target="_blank" style="color: #2977f5"
           >Exun Clan</a
         >
-        ('22-23). I am a freshman at
+        ('22-23) and a Computer Engineering student at the
         <a
           href="https://uwaterloo.ca/content/home"
           target="_blank"
           style="color: #5d0096"
           >University of Waterloo</a
-        >. I am also a Chapter Officer at the
+        > (CE '28). I am also a Chapter Officer at the
         <a
           href="//newdelhi.nss.org"
           target="_blank"
           style="color: rgb(110, 85, 192)"
           >New Delhi Space Society</a
         >, a chapter of the National Space Society, USA. I am a core maintainer
-        of <a href="//typewind.vercel.app" target="_blank">Typewind</a>.
+        of <a href="//typewind.vercel.app" target="_blank">Typewind</a> (2.2K+ stars).
       </p>
       <ul>
         <li><a href="mailto:mail@kavin.me">Email</a></li>


### PR DESCRIPTION
Updates the personal website bio to reflect current experience:

- Add Vercel as current SWE Intern position
- Add Helicone (YC W23) and AI Gateway experience
- Update tech stack to TypeScript, JavaScript, Python, Rust (dropping PHP as primary)
- Update education from 'freshman' to 'CE 28'
- Add Typewind star count (2.2K+)

Related to matching updates in kavinvalli/kavinvalli.github.io.