### PR TITLE
Update bio, experience, and links to reflect current roles

### DIFF
--- a/index.html
+++ b/index.html
@@ -123,37 +123,46 @@
         <img src="me.jpeg" alt="Me" />
         <p>
           <strong>Kavin Valli</strong
-          ><span style="color: #666">, student and developer</span>
+          ><span style="color: #666">, developer and student</span>
         </p>
       </div>
       <p>
         My name is <strong>Kavin</strong> and I am a
-        <strong>fullstack web developer</strong>
+        <strong>fullstack developer</strong>
         experienced in
-        <strong>Javascript, Typescript, Python and PHP</strong> and have also
-        worked with frameworks like
-        <strong>ReactJS, Express, Django and Laravel</strong>. I also have
-        experience doing <strong>App Development with Flutter</strong>.
+        <strong>TypeScript, JavaScript, Python, Rust, and PHP</strong>.
+        Currently a <strong>Software Engineer Intern</strong> at
+        <a href="https://vercel.com" target="_blank">Vercel</a>, working on
+        <a href="https://v0.dev" target="_blank">v0</a>.
+      </p>
+      <p>
+        Previously shipped 250+ merged PRs at
+        <a href="https://www.helicone.ai" target="_blank">Helicone</a>
+        (YC W23), building their AI gateway, LLM observability dashboard,
+        and multilingual SDKs. Before that, built embedded full-stack systems at
+        <a href="https://www.arcturusnetworks.com" target="_blank"
+          >Arcturus Networks</a
+        >.
       </p>
       <p>
         I am a former President of
         <a href="https://exunclan.com" target="_blank" style="color: #2977f5"
           >Exun Clan</a
         >
-        ('22-23). I am a freshman at
+        ('22-23), studying Computer Engineering at the
         <a
-          href="https://uwaterloo.ca/content/home"
+          href="https://uwaterloo.ca"
           target="_blank"
           style="color: #5d0096"
           >University of Waterloo</a
-        >. I am also a Chapter Officer at the
+        > (Class of 2028). Also a Chapter Officer at the
         <a
-          href="//newdelhi.nss.org"
+          href="https://new-delhi-space-society.github.io"
           target="_blank"
           style="color: rgb(110, 85, 192)"
           >New Delhi Space Society</a
-        >, a chapter of the National Space Society, USA. I am a core maintainer
-        of <a href="//typewind.vercel.app" target="_blank">Typewind</a>.
+        > and a core maintainer of
+        <a href="https://typewind.vercel.app" target="_blank">Typewind</a>.
       </p>
       <ul>
         <li><a href="mailto:mail@kavin.me">Email</a></li>
@@ -161,7 +170,7 @@
         <li>
           <a href="//linkedin.com/in/kavinvalli" target="_blank">Linkedin</a>
         </li>
-        <li><a href="//twitter.com/kavinvalli" target="_blank">Twitter</a></li>
+        <li><a href="//x.com/kavinvalli" target="_blank">Twitter/X</a></li>
         <li><a href="//livecode247.com" target="_blank">Blog</a></li>
         <li>
           <a href="//youtube.com/@livecode247" target="_blank"


### PR DESCRIPTION
Updates the static site at n.kavin.me to reflect current experience and roles.

### What changed
- Updated bio to highlight current SWE intern role at Vercel (working on v0)
- Added Helicone (YC W23) experience — 250+ merged PRs building the AI gateway, observability dashboard, and multilingual SDKs
- Added Arcturus Networks experience
- Updated skills to include Rust and current tech stack
- Updated education to reflect Class of 2028 at UWaterloo
- Replaced Facebook link with Twitter/X
- Changed subtitle from 'student and developer' to 'developer and student'

This PR is a companion to the kavinvalli.github.io terminal site updates.